### PR TITLE
Allow attribute to return None

### DIFF
--- a/TagScriptEngine/adapter/discordadapters.py
+++ b/TagScriptEngine/adapter/discordadapters.py
@@ -29,7 +29,7 @@ class AttributeAdapter(Adapter):
         else:
             param = self.attributes.get(ctx.parameter)
             return_value = str(param) if param is not None else None
-        return escape_content(return_value)
+        return escape_content(return_value) if return_value is not None else None
 
 
 class MemberAdapter(AttributeAdapter):


### PR DESCRIPTION
If the parameter does not exist in attributes the interpreter will raise an error as you cannot pass "None" into escape_content