### PR TITLE
Add support for discord.py 2.0.0+

### DIFF
--- a/TagScriptEngine/adapter/discordadapters.py
+++ b/TagScriptEngine/adapter/discordadapters.py
@@ -13,7 +13,6 @@ __all__ = (
     "GuildAdapter",
 )
 
-
 class AttributeAdapter(Adapter):
     def __init__(self, base):
         self.object = base
@@ -103,7 +102,7 @@ class MemberAdapter(AttributeAdapter):
             "color": self.object.color,
             "colour": self.object.color,
             "nick": self.object.display_name,
-            "avatar": (self.object.avatar_url, False),
+            "avatar": ((getattr(self.object, 'avatar_url', None) or (getattr(self.object, 'avatar') )), False),
             "discriminator": self.object.discriminator,
             "joined_at": getattr(self.object, "joined_at", self.object.created_at),
             "mention": self.object.mention,
@@ -200,7 +199,7 @@ class GuildAdapter(AttributeAdapter):
             else:
                 humans += 1
         additional_attributes = {
-            "icon": (guild.icon_url, False),
+            "icon": ((getattr(guild, 'icon_url', None) or (getattr(guild, 'icon') ), False),
             "member_count": guild.member_count,
             "bots": bots,
             "humans": humans,

--- a/TagScriptEngine/adapter/discordadapters.py
+++ b/TagScriptEngine/adapter/discordadapters.py
@@ -199,7 +199,7 @@ class GuildAdapter(AttributeAdapter):
             else:
                 humans += 1
         additional_attributes = {
-            "icon": ((getattr(guild, 'icon_url', None) or (getattr(guild, 'icon') ), False),
+            "icon": ((getattr(guild, 'icon_url', None) or (getattr(guild, 'icon') ), False)),
             "member_count": guild.member_count,
             "bots": bots,
             "humans": humans,


### PR DESCRIPTION
Used `getattr` on the Guild / Member adapters for fetching the avatars / icon.

In d.py's latest updates `avatar_url` and `icon_url` have depreciated which means people using the master branch will have errors when using these adapters. So i made a temporary fix