### PR TITLE
Lock discord.py's version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/TagScriptEngine/__init__.py
+++ b/TagScriptEngine/__init__.py
@@ -8,7 +8,7 @@ from .interpreter import *
 from .utils import *
 from .verb import Verb
 
-__version__ = "2.6.2"
+__version__ = "2.7.0"
 
 
 # github co-pilot automatically wrote the documentation for this and I decided to keep it

--- a/TagScriptEngine/adapter/discordadapters.py
+++ b/TagScriptEngine/adapter/discordadapters.py
@@ -224,4 +224,4 @@ class GuildAdapter(AttributeAdapter):
         self._methods.update(additional_methods)
 
     def random_member(self):
-        return choice(self.object.members)
+        return MemberAdapter(choice(self.object.members))

--- a/TagScriptEngine/adapter/discordadapters.py
+++ b/TagScriptEngine/adapter/discordadapters.py
@@ -3,8 +3,8 @@ from random import choice
 from discord import TextChannel
 
 from ..interface import Adapter
+from ..interpreter import Context
 from ..utils import escape_content
-from ..verb import Verb
 
 __all__ = (
     "AttributeAdapter",
@@ -38,16 +38,16 @@ class AttributeAdapter(Adapter):
     def update_methods(self):
         pass
 
-    def get_value(self, ctx: Verb) -> str:
+    def get_value(self, ctx: Context) -> str:
         should_escape = False
 
-        if ctx.parameter is None:
+        if ctx.verb.parameter is None:
             return_value = str(self.object)
         else:
             try:
-                value = self._attributes[ctx.parameter]
+                value = self._attributes[ctx.verb.parameter]
             except KeyError:
-                if method := self._methods.get(ctx.parameter):
+                if method := self._methods.get(ctx.verb.parameter):
                     value = method()
                 else:
                     return
@@ -218,10 +218,13 @@ class GuildAdapter(AttributeAdapter):
             "description": guild.description or "No description.",
         }
         self._attributes.update(additional_attributes)
-
-    def update_methods(self):
-        additional_methods = {"random": self.random_member}
-        self._methods.update(additional_methods)
-
+        
     def random_member(self):
         return MemberAdapter(choice(self.object.members))
+    
+    def get_value(self, ctx: Context) -> str:
+        if ctx.verb.parameter == "random":
+            ctx.response.variables["random"] = self.random_member()
+            return "{random}"
+        
+        return super().get_value(ctx)

--- a/TagScriptEngine/adapter/functionadapter.py
+++ b/TagScriptEngine/adapter/functionadapter.py
@@ -1,7 +1,7 @@
 from typing import Callable
 
 from ..interface import Adapter
-from ..verb import Verb
+from ..interpreter import Context
 
 
 class FunctionAdapter(Adapter):
@@ -14,5 +14,5 @@ class FunctionAdapter(Adapter):
     def __repr__(self):
         return f"<{type(self).__qualname__} fn={self.fn!r}>"
 
-    def get_value(self, ctx: Verb) -> str:
+    def get_value(self, ctx: Context) -> str:
         return str(self.fn())

--- a/TagScriptEngine/adapter/intadapter.py
+++ b/TagScriptEngine/adapter/intadapter.py
@@ -1,5 +1,5 @@
 from ..interface import Adapter
-from ..verb import Verb
+from ..interpreter import Context
 
 
 class IntAdapter(Adapter):
@@ -11,5 +11,5 @@ class IntAdapter(Adapter):
     def __repr__(self):
         return f"<{type(self).__qualname__} integer={repr(self.integer)}>"
 
-    def get_value(self, ctx: Verb) -> str:
+    def get_value(self, ctx: Context) -> str:
         return str(self.integer)

--- a/TagScriptEngine/adapter/objectadapter.py
+++ b/TagScriptEngine/adapter/objectadapter.py
@@ -1,7 +1,7 @@
 from inspect import ismethod
 
 from ..interface import Adapter
-from ..verb import Verb
+from ..interpreter import Context
 
 
 class SafeObjectAdapter(Adapter):
@@ -13,13 +13,13 @@ class SafeObjectAdapter(Adapter):
     def __repr__(self):
         return f"<{type(self).__qualname__} object={repr(self.object)}>"
 
-    def get_value(self, ctx: Verb) -> str:
-        if ctx.parameter is None:
+    def get_value(self, ctx: Context) -> str:
+        if ctx.verb.parameter is None:
             return str(self.object)
-        if ctx.parameter.startswith("_") or "." in ctx.parameter:
+        if ctx.verb.parameter.startswith("_") or "." in ctx.verb.parameter:
             return
         try:
-            attribute = getattr(self.object, ctx.parameter)
+            attribute = getattr(self.object, ctx.verb.parameter)
         except AttributeError:
             return
         if ismethod(attribute):

--- a/TagScriptEngine/adapter/stringadapter.py
+++ b/TagScriptEngine/adapter/stringadapter.py
@@ -1,6 +1,6 @@
 from ..interface import Adapter
 from ..utils import escape_content
-from ..verb import Verb
+from ..interpreter import Context
 
 
 class StringAdapter(Adapter):
@@ -13,23 +13,23 @@ class StringAdapter(Adapter):
     def __repr__(self):
         return f"<{type(self).__qualname__} string={repr(self.string)}>"
 
-    def get_value(self, ctx: Verb) -> str:
+    def get_value(self, ctx: Context) -> str:
         return self.return_value(self.handle_ctx(ctx))
 
-    def handle_ctx(self, ctx: Verb) -> str:
-        if ctx.parameter is None:
+    def handle_ctx(self, ctx: Context) -> str:
+        if ctx.verb.parameter is None:
             return self.string
         try:
-            if "+" not in ctx.parameter:
-                index = int(ctx.parameter) - 1
-                splitter = " " if ctx.payload is None else ctx.payload
+            if "+" not in ctx.verb.parameter:
+                index = int(ctx.verb.parameter) - 1
+                splitter = " " if ctx.verb.payload is None else ctx.verb.payload
                 return self.string.split(splitter)[index]
             else:
-                index = int(ctx.parameter.replace("+", "")) - 1
-                splitter = " " if ctx.payload is None else ctx.payload
-                if ctx.parameter.startswith("+"):
+                index = int(ctx.verb.parameter.replace("+", "")) - 1
+                splitter = " " if ctx.verb.payload is None else ctx.verb.payload
+                if ctx.verb.parameter.startswith("+"):
                     return splitter.join(self.string.split(splitter)[: index + 1])
-                elif ctx.parameter.endswith("+"):
+                elif ctx.verb.parameter.endswith("+"):
                     return splitter.join(self.string.split(splitter)[index:])
                 else:
                     return self.string.split(splitter)[index]

--- a/TagScriptEngine/adapter/stringadapter.py
+++ b/TagScriptEngine/adapter/stringadapter.py
@@ -1,6 +1,6 @@
 from ..interface import Adapter
 from ..utils import escape_content
-from ..interpreter import Context
+from ..interpreter import Context, log
 
 
 class StringAdapter(Adapter):
@@ -9,6 +9,14 @@ class StringAdapter(Adapter):
     def __init__(self, string: str, *, escape: bool = False):
         self.string: str = str(string)
         self.escape_content = escape
+        self._methods = {
+            "lower": str.lower,
+            "upper": str.upper,
+            "title": str.title,
+            "capitalize": str.capitalize,
+            "swapcase": str.swapcase,
+            "strip": str.strip,
+        }
 
     def __repr__(self):
         return f"<{type(self).__qualname__} string={repr(self.string)}>"
@@ -20,11 +28,11 @@ class StringAdapter(Adapter):
         if ctx.verb.parameter is None:
             return self.string
         try:
-            if "+" not in ctx.verb.parameter:
+            if "+" not in ctx.verb.parameter and ctx.verb.parameter.isdigit():
                 index = int(ctx.verb.parameter) - 1
                 splitter = " " if ctx.verb.payload is None else ctx.verb.payload
                 return self.string.split(splitter)[index]
-            else:
+            elif "+" in ctx.verb.parameter and ctx.verb.parameter.replace("+", "").isdigit():
                 index = int(ctx.verb.parameter.replace("+", "")) - 1
                 splitter = " " if ctx.verb.payload is None else ctx.verb.payload
                 if ctx.verb.parameter.startswith("+"):
@@ -33,7 +41,20 @@ class StringAdapter(Adapter):
                     return splitter.join(self.string.split(splitter)[index:])
                 else:
                     return self.string.split(splitter)[index]
-        except:
+                
+            elif ctx.verb.parameter == "split":
+                if ctx.verb.payload is None:
+                    return self.string
+                
+                else:
+                    return " ".join(self.string.split(ctx.verb.payload))
+                
+            else:
+                return self._methods[ctx.verb.parameter](self.string)
+                
+                
+        except Exception as e:
+            log.exception("Error in string", exc_info=e)
             return self.string
 
     def return_value(self, string: str) -> str:

--- a/TagScriptEngine/block/__init__.py
+++ b/TagScriptEngine/block/__init__.py
@@ -16,6 +16,7 @@ from .range import RangeBlock
 from .redirect import RedirectBlock
 from .replaceblock import PythonBlock, ReplaceBlock
 from .require_blacklist import BlacklistBlock, RequireBlock
+from .send import SendBlock
 from .shortcutredirect import ShortCutRedirectBlock
 from .stopblock import StopBlock
 from .strf import StrfBlock
@@ -47,6 +48,7 @@ __all__ = (
     "RedirectBlock",
     "ReplaceBlock",
     "RequireBlock",
+    "SendBlock",
     "ShortCutRedirectBlock",
     "StopBlock",
     "StrfBlock",

--- a/TagScriptEngine/block/embedblock.py
+++ b/TagScriptEngine/block/embedblock.py
@@ -7,6 +7,7 @@ from discord import Colour, Embed
 from ..exceptions import BadColourArgument, EmbedParseError
 from ..interface import Block
 from ..interpreter import Context
+from ..adapter import StringAdapter
 from .helpers import helper_split, implicit_bool
 
 
@@ -136,9 +137,13 @@ class EmbedBlock(Block):
         "field": add_field,
     }
 
-    @staticmethod
-    def get_embed(ctx: Context) -> Embed:
-        return Embed.from_dict(ctx.response.variables.get("__emb", Embed().to_dict()))
+    def get_embed(self, ctx: Context) -> Embed:
+        emb = ctx.response.variables.get("__emb", "")
+        if emb:
+            return self.text_to_embed(emb.string) 
+        
+        else:
+            return Embed()
 
     @staticmethod
     def value_to_color(value: Optional[Union[int, str]]) -> Colour:
@@ -172,7 +177,7 @@ class EmbedBlock(Block):
             if color := self.value_to_color(color):
                 embed.color = color
             return embed
-
+        
     @classmethod
     def update_embed(cls, embed: Embed, attribute: str, value: str) -> Embed:
         handler = cls.ATTRIBUTE_HANDLERS[attribute]
@@ -194,7 +199,7 @@ class EmbedBlock(Block):
             return str(error)
         if length > 6000:
             return f"`MAX EMBED LENGTH REACHED ({length}/6000)`"
-        ctx.response.variables["__emb"] = embed
+        ctx.response.variables["__emb"] = StringAdapter(json.dumps(embed.to_dict()))
         return ""
 
     def process(self, ctx: Context) -> Optional[str]:

--- a/TagScriptEngine/block/embedblock.py
+++ b/TagScriptEngine/block/embedblock.py
@@ -138,7 +138,7 @@ class EmbedBlock(Block):
 
     @staticmethod
     def get_embed(ctx: Context) -> Embed:
-        return ctx.response.actions.get("embed", Embed())
+        return Embed.from_dict(ctx.response.variables.get("__emb", Embed().to_dict()))
 
     @staticmethod
     def value_to_color(value: Optional[Union[int, str]]) -> Colour:
@@ -194,7 +194,7 @@ class EmbedBlock(Block):
             return str(error)
         if length > 6000:
             return f"`MAX EMBED LENGTH REACHED ({length}/6000)`"
-        ctx.response.actions["embed"] = embed
+        ctx.response.variables["__emb"] = embed
         return ""
 
     def process(self, ctx: Context) -> Optional[str]:

--- a/TagScriptEngine/block/loosevariablegetter.py
+++ b/TagScriptEngine/block/loosevariablegetter.py
@@ -30,6 +30,6 @@ class LooseVariableGetterBlock(Block):
 
     def process(self, ctx: Context) -> Optional[str]:
         if ctx.verb.declaration in ctx.response.variables:
-            return ctx.response.variables[ctx.verb.declaration].get_value(ctx.verb)
+            return ctx.response.variables[ctx.verb.declaration].get_value(ctx)
         else:
             return None

--- a/TagScriptEngine/block/send.py
+++ b/TagScriptEngine/block/send.py
@@ -1,3 +1,4 @@
+from ..adapter import StringAdapter
 from ..interface import verb_required_block
 from ..interpreter import Context
 from .embedblock import EmbedBlock
@@ -13,47 +14,50 @@ class SendBlock(verb_required_block(explicit=True, parameter=True, payload=True)
     This block can be used multiple times It tries to append the payload to the existing message.
     or it will send a new message.
     """
+    ACCEPTED_NAMES = ("send",)
     
     def will_accept(self, ctx: Context) -> bool:
-        return super().will_accept(ctx) and ctx.verb.parameter in ["message", "embed"]
+        b = super().will_accept(ctx) and ctx.verb.parameter.lower() in ["message", "embed"]
+        return b
     
     def process(self, ctx: Context) -> Optional[str]:
-        to_send = ctx.response.actions.get("send", [{"message": "", "embed": None}])
+        to_send = ctx.response.actions.get("send", [{"content": "", "embed": None}])
         
         param = ctx.verb.parameter
         payload = ctx.verb.payload
         
-        thing_to_send = param or "message"
+        thing_to_send = param or "content"
         
         
         for ind, send_dict in enumerate(to_send.copy()):
             
-            object_to_send = send_dict[ind][thing_to_send]
+            thing_to_send = "content" if thing_to_send == "message" else "embed"
             
-            try:
-                object_to_send = EmbedBlock().text_to_embed(payload)
-                
-            except Exception:
-                pass
+            object_to_send = send_dict[thing_to_send]
+            
+            if thing_to_send == "embed":
+                if payload == "{__emb}":
+                    payload = ctx.response.variables.get("__emb", StringAdapter("")).string
+                payload = EmbedBlock().text_to_embed(payload)
             
             if object_to_send is None:
                 to_send[ind][thing_to_send] = payload
                 
             elif isinstance(object_to_send, Embed):
-                to_send.append({"message": "", "embed": object_to_send})
+                to_send.append({"content": "", "embed": payload})
                 
             elif object_to_send == "":
                 to_send[ind][thing_to_send] = payload
                 
             elif object_to_send == payload:
-                pass
+                continue
             
             elif len(object_to_send) >= 4096:
                 org_msg = object_to_send[:4093] + "..."
                 new_msg = object_to_send[4093:] + "\n\n" + payload
             
                 to_send[ind][thing_to_send] = org_msg
-                to_send.append({"message": new_msg, "embed": None})
+                to_send.append({"content": new_msg, "embed": None})
             
             else:
                 to_send[ind][thing_to_send] = object_to_send + "\n\n" + payload

--- a/TagScriptEngine/block/send.py
+++ b/TagScriptEngine/block/send.py
@@ -1,0 +1,62 @@
+from ..interface import verb_required_block
+from ..interpreter import Context
+from .embedblock import EmbedBlock
+from discord import Embed
+
+from typing import Optional
+
+class SendBlock(verb_required_block(explicit=True, parameter=True, payload=True)):
+    """
+    The send block sends the payload to the channel the tagscript was run in.
+    
+    A parameter can be specified to differ between sending an embed or a plain message.
+    This block can be used multiple times It tries to append the payload to the existing message.
+    or it will send a new message.
+    """
+    
+    def will_accept(self, ctx: Context) -> bool:
+        return super().will_accept(ctx) and ctx.verb.parameter in ["message", "embed"]
+    
+    def process(self, ctx: Context) -> Optional[str]:
+        to_send = ctx.response.actions.get("send", [{"message": "", "embed": None}])
+        
+        param = ctx.verb.parameter
+        payload = ctx.verb.payload
+        
+        thing_to_send = param or "message"
+        
+        
+        for ind, send_dict in enumerate(to_send.copy()):
+            
+            object_to_send = send_dict[ind][thing_to_send]
+            
+            try:
+                object_to_send = EmbedBlock().text_to_embed(payload)
+                
+            except Exception:
+                pass
+            
+            if object_to_send is None:
+                to_send[ind][thing_to_send] = payload
+                
+            elif isinstance(object_to_send, Embed):
+                to_send.append({"message": "", "embed": object_to_send})
+                
+            elif object_to_send == "":
+                to_send[ind][thing_to_send] = payload
+                
+            elif object_to_send == payload:
+                pass
+            
+            elif len(object_to_send) >= 4096:
+                org_msg = object_to_send[:4093] + "..."
+                new_msg = object_to_send[4093:] + "\n\n" + payload
+            
+                to_send[ind][thing_to_send] = org_msg
+                to_send.append({"message": new_msg, "embed": None})
+            
+            else:
+                to_send[ind][thing_to_send] = object_to_send + "\n\n" + payload
+                
+        ctx.response.actions.update({"send": to_send})
+        return ""

--- a/TagScriptEngine/block/strictvariablegetter.py
+++ b/TagScriptEngine/block/strictvariablegetter.py
@@ -30,4 +30,4 @@ class StrictVariableGetterBlock(Block):
         return ctx.verb.declaration in ctx.response.variables
 
     def process(self, ctx: Context) -> Optional[str]:
-        return ctx.response.variables[ctx.verb.declaration].get_value(ctx.verb)
+        return ctx.response.variables[ctx.verb.declaration].get_value(ctx)

--- a/TagScriptEngine/interface/block.py
+++ b/TagScriptEngine/interface/block.py
@@ -71,13 +71,13 @@ class Block:
         """
         raise NotImplementedError
 
-    def post_process(self, ctx: "interpreter.Context"):
+    def post_process(self, ctx: Context):
         return None
 
 
 @lru_cache(maxsize=None)
 def verb_required_block(
-    implicit: bool,
+    explicit: bool,
     *,
     parameter: bool = False,
     payload: bool = False,
@@ -87,19 +87,19 @@ def verb_required_block(
 
     Parameters
     ----------
-    implicit: bool
+    explicit: bool
         Specifies whether the value is required to be passed implicitly or explicitly.
-        ``{block()}`` would be allowed if implicit is False.
+        ``{block()}`` would be allowed if explicit is False.
     parameter: bool
         Passing True will cause the block to require a parameter to be passed.
     payload: bool
         Passing True will cause the block to require the payload to be passed.
     """
-    check = (lambda x: x) if implicit else (lambda x: x is not None)
+    check = (lambda x: x) if explicit else (lambda x: x is not None)
 
     class RequireMeta(type):
         def __repr__(self):
-            return f"VerbRequiredBlock(implicit={implicit!r}, payload={payload!r}, parameter={parameter!r})"
+            return f"VerbRequiredBlock(explicit={explicit!r}, payload={payload!r}, parameter={parameter!r})"
 
     class VerbRequiredBlock(Block, metaclass=RequireMeta):
         def will_accept(self, ctx: Context) -> bool:

--- a/TagScriptEngine/interpreter.py
+++ b/TagScriptEngine/interpreter.py
@@ -270,6 +270,7 @@ class Interpreter:
         *,
         charlimit: Optional[int] = None,
         dot_parameter: bool = False,
+        process_output: bool = False,
         **kwargs,
     ) -> Response:
         """
@@ -316,7 +317,14 @@ class Interpreter:
             raise
         except Exception as error:
             raise ProcessError(error, response, self) from error
-        return self._return_response(response, output)
+        response = self._return_response(response, output)
+        if process_output:
+            new_resp = self.process(response.body, seed_variables, charlimit=charlimit, dot_paramter=dot_parameter, process_output=False, **kwargs)
+            new_resp.actions.update(response.actions)
+            new_resp.variables.update(response.variabled)
+            new_resp.extra_kwargs.update(response.extra_kwargs)
+            return new_resp
+        return response
 
 
 class AsyncInterpreter(Interpreter):

--- a/TagScriptEngine/interpreter.py
+++ b/TagScriptEngine/interpreter.py
@@ -61,20 +61,18 @@ def build_node_tree(message: str) -> List[Node]:
         A list of all possible text bracket blocks.
     """
     nodes = []
-    previous = r""
 
     starts = []
     for i, ch in enumerate(message):
-        if ch == "{" and previous != r"\\":
+        if ch == "{" and message[i-1] != r"\\":
             starts.append(i)
-        if ch == "}" and previous != r"\\":
+        if ch == "}" and message[i-1] != r"\\":
             if not starts:
                 continue
             coords = (starts.pop(), i)
             n = Node(coords)
             nodes.append(n)
-
-        previous = ch
+            
     return nodes
 
 

--- a/Tests/test_send.py
+++ b/Tests/test_send.py
@@ -1,0 +1,26 @@
+import unittest
+
+import TagScriptEngine as tse
+import discord
+
+class Sendtest(unittest.TestCase):
+    def setUp(self):
+        self.blocks = [
+            tse.SendBlock(),
+            tse.EmbedBlock(),
+        ]
+        self.engine = tse.Interpreter(self.blocks)
+
+    def tearDown(self):
+        self.blocks = None
+        self.engine = None
+        
+    def test_send(self):
+        resp = self.engine.process(
+            """
+            {embed(title):Hello} {embed(description):World}
+            {send(embed):{__emb}} {send(message):abcd}
+            {embed({"title": "test", "description":"Test", "author": {"name": "test", "url": "test"}})}
+            {send(embed):{__emb}}"""
+        )
+        self.assertEqual(resp.actions, {"send": [{"message": "abcd", "embed": discord.Embed(title="Hello", description="World")}, {"message": "", "embed": discord.Embed(title="test", description="Test").set_author(name="test", url="test")}]})

--- a/Tests/test_send.py
+++ b/Tests/test_send.py
@@ -19,8 +19,15 @@ class Sendtest(unittest.TestCase):
         resp = self.engine.process(
             """
             {embed(title):Hello} {embed(description):World}
-            {send(embed):{__emb}} {send(message):abcd}
+            {send(message):abcd}
             {embed({"title": "test", "description":"Test", "author": {"name": "test", "url": "test"}})}
             {send(embed):{__emb}}"""
         )
+        print(resp)
         self.assertEqual(resp.actions, {"send": [{"message": "abcd", "embed": discord.Embed(title="Hello", description="World")}, {"message": "", "embed": discord.Embed(title="test", description="Test").set_author(name="test", url="test")}]})
+        
+if __name__ == "__main__":
+    x = Sendtest()
+    x.setUp()
+    x.test_send()
+    x.tearDown()

--- a/playground.py
+++ b/playground.py
@@ -3,6 +3,8 @@ from appJar import gui
 from TagScriptEngine import Interpreter, block
 
 blocks = [
+    block.SendBlock(),
+    block.EmbedBlock(),
     block.MathBlock(),
     block.RandomBlock(),
     block.RangeBlock(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autoflake
 black
-discord.py
+discord.py==1.7.3
 isort
 pyparsing


### PR DESCRIPTION
Lock discord.py to version 1.7.3 since latest on pypi is 2.0.1 and this causes errors with pip with new installs of tagscript egnine.