### PR TITLE
Lock discord.py to version 1.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autoflake
 black
-discord.py
+discord.py==1.7.3
 isort
 pyparsing

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ keywords = tagscript,
 [options]
 packages = find_namespace:
 install_requires =
-    discord.py>=1.6
+    discord.py==1.7.3
     pyparsing
 python_requires = >=3.8
 


### PR DESCRIPTION
Lock discord.py to version 1.7.3 since latest on pypi is 2.0.1 and this causes errors with pip with new installs of tagscript egnine.